### PR TITLE
Expose original component as public static member WrappedComponent

### DIFF
--- a/src/withESI.test.tsx
+++ b/src/withESI.test.tsx
@@ -5,6 +5,11 @@ import withESI from "./withESI";
 
 const Dummy = (props: { name?: string }) => <div>Hello {props.name}</div>;
 
+test("exposes WrappedComponent", () => {
+  const DummyESI = withESI(Dummy, "id");
+  expect(DummyESI).toHaveProperty("WrappedComponent", Dummy);
+});
+
 test("client-side", () => {
   const DummyESI = withESI(Dummy, "id");
   expect(DummyESI.displayName).toBe("WithESI(Dummy)");

--- a/src/withESI.tsx
+++ b/src/withESI.tsx
@@ -26,6 +26,7 @@ export default function withESI<P>(
   fragmentID: string
 ) {
   return class WithESI extends React.Component<P> {
+    public static WrappedComponent = WrappedComponent;
     public static displayName = `WithESI(${WrappedComponent.displayName ||
       WrappedComponent.name ||
       "Component"})`;


### PR DESCRIPTION
Hi, this PR will add a public static property `WrappedComponent` (tests included) to access original component.

It looks like a *de facto* standard in *higher order components*, at least that's what `react-router` and `react-redux` do, so I expected any higher order component to do the same. This allows to access original component in a standardized way and access its original static properties (in my case, a `loadData` property used for server-side data fetching, but that could be anything else).

Thanks for your work!