### PR TITLE
Feature - add typescript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-esi",
   "description": "React ESI: Blazing-fast Server-Side Rendering for React and Next.js",
   "main": "lib/withESI.js",
+  "typings": "lib/withESI.d.ts",
   "repository": "https://github.com/dunglas/react-esi",
   "author": "Kévin Dunglas",
   "license": "MIT",

--- a/src/withESI.tsx
+++ b/src/withESI.tsx
@@ -27,7 +27,7 @@ export default function withESI<P>(
   WrappedComponent: React.ComponentType<P>,
   fragmentID: string
 ): React.ComponentClass<IWithESIProps & P> {
-  return class WithESI extends React.Component<P> {
+  return class WithESI extends React.Component<P & IWithESIProps> {
     public static WrappedComponent = WrappedComponent;
     public static displayName = `WithESI(${WrappedComponent.displayName ||
       WrappedComponent.name ||

--- a/src/withESI.tsx
+++ b/src/withESI.tsx
@@ -16,8 +16,8 @@ interface IWithESIProps {
   esi?: {
     attrs?: {
       [key: string]: string | null;
-    } | null;
-  } | null;
+    };
+  };
 }
 
 /**
@@ -26,20 +26,20 @@ interface IWithESIProps {
 export default function withESI<P>(
   WrappedComponent: React.ComponentType<P>,
   fragmentID: string
-): React.ComponentClass<P & IWithESIProps> {
-  return class WithESI extends React.Component<P & IWithESIProps> {
+): React.ComponentClass<IWithESIProps & P> {
+  return class WithESI extends React.Component<P> {
     public static WrappedComponent = WrappedComponent;
     public static displayName = `WithESI(${WrappedComponent.displayName ||
       WrappedComponent.name ||
       "Component"})`;
-    public static propTypes = ({
+    public static propTypes = {
       esi: PropTypes.shape({
-        attrs: PropTypes.objectOf(PropTypes.string), // extra attributes to add to the <esi:include> tag
-      }),
-    } as unknown) as WeakValidationMap<P & IWithESIProps>;
+        attrs: PropTypes.objectOf(PropTypes.string) // extra attributes to add to the <esi:include> tag
+      })
+    } as unknown as WeakValidationMap<IWithESIProps & P>;
     public state = {
       childProps: {},
-      initialChildPropsLoaded: true,
+      initialChildPropsLoaded: true
     };
     private esi = {};
 
@@ -57,7 +57,7 @@ export default function withESI<P>(
         // Inject server-side computed initial props
         this.state.childProps = {
           ...window.__REACT_ESI__[fragmentID],
-          ...this.state.childProps,
+          ...this.state.childProps
         };
         return;
       }
@@ -78,7 +78,7 @@ export default function withESI<P>(
         .then((initialProps: object) =>
           this.setState({
             childProps: initialProps,
-            initialChildPropsLoaded: true,
+            initialChildPropsLoaded: true
           })
         );
     }
@@ -87,7 +87,7 @@ export default function withESI<P>(
       if ((process as IWebpackProcess).browser) {
         return (
           <div>
-            <WrappedComponent {...(this.state.childProps as P)} />
+            <WrappedComponent {...this.state.childProps as P} />
           </div>
         );
       }
@@ -102,7 +102,7 @@ export default function withESI<P>(
               fragmentID,
               this.props,
               this.esi
-            ),
+            )
           }}
         />
       );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "esModuleInterop": true,
+        "esModuleInterop": true,        
         "allowSyntheticDefaultImports": true,
         "forceConsistentCasingInFileNames": true,
         "outDir": "./lib/",
@@ -13,7 +13,8 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "jsx": "react",
-        "target": "es5"
+        "target": "es5",
+        "declaration": true
     },
     "include": [
         "./src/"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "esModuleInterop": true,        
+        "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
         "forceConsistentCasingInFileNames": true,
         "outDir": "./lib/",


### PR DESCRIPTION
Hi,

Thanks for this awesome library.

With this PR, I'd like to add typings to the package.

There were a couple of issues with typing withESI:
* **Return type**  - With declarations enabled, typescript generated an error: the esi property cannot be private/protected in the HOC class. That is, exported anonymous classes can't have private or protected members if declaration emit is enabled, because there's no way to represent that in a .d.ts file. I resolved it by providing an return type to withESI `React.ComponentClass<P & IWithESIProps>`
* **propTypes**  - The problem with this return type is that the static `propTypes` member did not account for child properties as provided by the generic variable `P`. This generated another typescript error. I resolved it by converting the propTypes member first to unknown and then to the proper `WeakValidationMap` type to account for HOC props and the children props.  
