### PR TITLE
Feature - add option to further pipe stream

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -173,10 +173,8 @@ export async function serveFragment(
     { end: false }
   );
 
-  let lastStream: NodeJS.ReadableStream = removeReactRootStream;
-  if (options.pipeStream) {
-    lastStream = options.pipeStream(removeReactRootStream);
-  }
+  const lastStream: NodeJS.ReadableStream =  options.pipeStream ? options.pipeStream(removeReactRootStream) : removeReactRootStream;
+  
   lastStream.pipe(
     res,
     { end: false }

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -106,6 +106,10 @@ class RemoveReactRoot extends Transform {
   }
 }
 
+interface IServeFragmentOptions {
+  pipeStream?: (stream: NodeJS.ReadableStream) => NodeJS.ReadableStream;
+}
+
 type resolver = (
   fragmentID: string,
   props: object,
@@ -119,7 +123,8 @@ type resolver = (
 export async function serveFragment(
   req: Request,
   res: Response,
-  resolve: resolver
+  resolve: resolver,
+  options: IServeFragmentOptions = {}
 ) {
   const url = new URL(req.url, "http://example.com");
   const expectedSign = url.searchParams.get("sign");
@@ -161,12 +166,18 @@ export async function serveFragment(
       <Component {...childProps} />
     </div>
   );
+
   const removeReactRootStream = new RemoveReactRoot();
   stream.pipe(
     removeReactRootStream,
     { end: false }
   );
-  removeReactRootStream.pipe(
+
+  let lastStream: NodeJS.ReadableStream = removeReactRootStream;
+  if (options.pipeStream) {
+    lastStream = options.pipeStream(removeReactRootStream);
+  }
+  lastStream.pipe(
     res,
     { end: false }
   );


### PR DESCRIPTION
Hi,

This PR aims to expose the serveFragment stream to the library user. That is, an option to provide any extra pipes on the stream is provided. With this option, users can further transform the fragment output as desired. I created this PR because I needed to add rendered styles from emotion to the served fragment. 

Changes:
* **options** I've added an options argument to serveFragments. I was assuming that more options could follow
* **options.pipeStream** After removing the react root transform stream, it will check if option.pipeStream is provided and executes it.

I'd be happy to implement any desired changes.