### PR TITLE
fix: content truncated because response end is called too early

### DIFF
--- a/src/server.test.tsx
+++ b/src/server.test.tsx
@@ -73,10 +73,7 @@ test("serveFragment with pipeStream option", async () => {
             callback(undefined, "<div>hi there</div>");
           },
         });
-        input.pipe(
-          transformer,
-          { end: false }
-        );
+        input.pipe(transformer);
         return transformer;
       },
     })

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -168,17 +168,9 @@ export async function serveFragment(
   );
 
   const removeReactRootStream = new RemoveReactRoot();
-  stream.pipe(
-    removeReactRootStream,
-    { end: false }
-  );
+  stream.pipe(removeReactRootStream);
 
   const lastStream: NodeJS.ReadableStream =  options.pipeStream ? options.pipeStream(removeReactRootStream) : removeReactRootStream;
   
-  lastStream.pipe(
-    res,
-    { end: false }
-  );
-
-  stream.on("end", () => res.end());
+  lastStream.pipe(res);
 }


### PR DESCRIPTION
In some case the res.end is called too early. We should let the pipe end the writer when the reader ends.

Tested with large ESI. 
The transformation is working but the last part is not sent.