### PR TITLE
fix: repair build and add react 18 to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "peerDependencies": {
-    "react": "^16.7.0 || 17"
+    "react": "^16.7.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.16.1",

--- a/src/server.test.tsx
+++ b/src/server.test.tsx
@@ -71,11 +71,11 @@ test("serveFragment with pipeStream option", async () => {
         const transformer = new Stream.Transform({
           transform: (chunk, encoding, callback) => {
             callback(undefined, "<div>hi there</div>");
-          },
+          }
         });
         input.pipe(transformer);
         return transformer;
-      },
+      }
     })
   );
 
@@ -83,7 +83,8 @@ test("serveFragment with pipeStream option", async () => {
     .get(fragmentURL)
     .set("user-agent", "test")
     .expect(200);
-  const addedScript = "<script>window.__REACT_ESI__ = window.__REACT_ESI__ || {}; window.__REACT_ESI__['fragmentID'] = {\"name\":\"Kévin\"};document.currentScript.remove();</script>";
+  const addedScript =
+    '<script>window.__REACT_ESI__ = window.__REACT_ESI__ || {}; window.__REACT_ESI__[\'fragmentID\'] = {"name":"Kévin"};document.currentScript.remove();</script>';
   expect(response.text).toEqual(`${addedScript}<div>hi there</div>`);
 });
 

--- a/src/withESI.tsx
+++ b/src/withESI.tsx
@@ -89,7 +89,9 @@ export default function withESI<P>(
       if ((process as IWebpackProcess).browser) {
         return (
           <div>
-            <WrappedComponent {...(this.state.childProps as React.JSX.IntrinsicAttributes&P)} />
+            <WrappedComponent
+              {...(this.state.childProps as React.JSX.IntrinsicAttributes & P)}
+            />
           </div>
         );
       }


### PR DESCRIPTION
3 small things with this PR:

- did `yarn cs` to prettier all files
- repairing the build: when building locally i had an error (wrong types), typing the resolver solves it
- add react 18 to the peerDependencies: tested on a fresh nextjs 13 install locally, all works except an error from the server (see logs below). Client side everything seems working.

```
❯ npm run dev

> my-app@0.1.0 dev
> next dev

- ready started server on 0.0.0.0:3000, url: http://localhost:3000
- event compiled client and server successfully in 155 ms (20 modules)
- wait compiling...
- event compiled client and server successfully in 99 ms (20 modules)
- wait compiling /page (client and server)...
- event compiled client and server successfully in 1059 ms (444 modules)
- wait compiling...
- event compiled successfully in 125 ms (220 modules)
- error Error: Cannot find module './server'
Require stack:
- /home/fabious/Code/my-app/.next/server/app/page.js